### PR TITLE
Fix/hanging with multiprocessing issue

### DIFF
--- a/tools/dataset_converters/create_gt_database.py
+++ b/tools/dataset_converters/create_gt_database.py
@@ -610,11 +610,11 @@ class GTDatabaseCreater:
             input_dict['box_mode_3d'] = self.dataset.box_mode_3d
             return input_dict
 
-        multi_db_infos = mmengine.track_parallel_progress(
+        multi_db_infos = mmengine.track_progress(
             self.create_single,
             ((loop_dataset(i)
-              for i in range(len(self.dataset))), len(self.dataset)),
-            self.num_worker)
+              for i in range(len(self.dataset))), len(self.dataset)))
+
         print('Make global unique group id')
         group_counter_offset = 0
         all_db_infos = dict()

--- a/tools/dataset_converters/update_infos_to_v2.py
+++ b/tools/dataset_converters/update_infos_to_v2.py
@@ -881,6 +881,7 @@ def update_waymo_infos(pkl_path, out_dir):
         'CAM_SIDE_LEFT',
         'CAM_SIDE_RIGHT',
     ]
+    ignore_class_name = set()
     print(f'{pkl_path} will be modified.')
     if out_dir in pkl_path:
         print(f'Warning, you may overwriting '
@@ -972,7 +973,6 @@ def update_waymo_infos(pkl_path, out_dir):
             temp_data_info['image_sweeps'].append(image_sweep)
 
         anns = ori_info_dict.get('annos', None)
-        ignore_class_name = set()
         if anns is not None:
             num_instances = len(anns['name'])
 


### PR DESCRIPTION
https://github.com/open-mmlab/mmdetection3d/pull/2065 - probably same problem as ours. It points out that the issue is connected to `torch.einsum` function when run with multiprocessing. 

It is run by `box_np_ops.points_in_rbbox` function which is run in two places with multiprocessing ([`kitti_converter/_NumPointsInGTCalculater/calculate_single`](https://github.com/pawel-kotowski/mmdetection3d/blob/3c5e5df3e27285d3d2a6e94b4979243a3487c1f8/tools/dataset_converters/kitti_converter.py#L103) and [`create_gt_database.py/create_single`](https://github.com/pawel-kotowski/mmdetection3d/blob/3c5e5df3e27285d3d2a6e94b4979243a3487c1f8/tools/dataset_converters/create_gt_database.py#L424))

[This](https://github.com/open-mmlab/mmdetection3d/issues/2371) issue describes similar problem in `create_gt_database.py` (I confirmed it also hangs).

Proposed solution (`import multiprocessing; multiprocessing.set_start_method('spawn')`) didn't work for me (cuda out of memory error).


But knowing it is related to einsum and multiprocessing I found [this](https://github.com/pytorch/pytorch/issues/17199) issue. I applied a proposed solution from [this](https://github.com/pytorch/pytorch/issues/17199#issuecomment-1681625868) comment (running `einsum` in separate thread). It seems to solve the problem for ([`kitti_converter/_NumPointsInGTCalculater/calculate_single`](https://github.com/pawel-kotowski/mmdetection3d/blob/3c5e5df3e27285d3d2a6e94b4979243a3487c1f8/tools/dataset_converters/kitti_converter.py#L103).

It doesn't work for [`create_gt_database.py/create_single`](https://github.com/pawel-kotowski/mmdetection3d/blob/3c5e5df3e27285d3d2a6e94b4979243a3487c1f8/tools/dataset_converters/create_gt_database.py#L424)) though so I disabled multiprocessing there. I may not be a big problem though if it takes only a couple of hours to create a db using one process as described [here](https://github.com/open-mmlab/mmdetection3d/issues/2371).

The problem with `ignore_class_name` from [here](https://www.notion.so/robotec-ai/test-WaymoDataset-and-CenterPoint-8e646c8ef8a54bd5abb4b444916d188f?pvs=4#ca08de5355b94c4a8168627164f1411a) is also fixed - it happened when one of pkl files was empty as the  `ignore_class_name` set was not initialized.

Related links:
https://github.com/open-mmlab/mmdetection3d/pull/2065
https://github.com/open-mmlab/mmdetection3d/pull/2143
https://github.com/open-mmlab/mmdetection3d/issues/2371
https://github.com/pytorch/pytorch/issues/17199
